### PR TITLE
Implement day 1 puzzle : inverse captcha but using halfway around digits for comparison (Saint agericus)

### DIFF
--- a/src/clj_advent_of_code_2017/agericus.clj
+++ b/src/clj_advent_of_code_2017/agericus.clj
@@ -22,3 +22,33 @@
           (recur (+ acc (-> partitioned-digits first first))
                  (rest partitioned-digits))
           (recur acc (rest partitioned-digits)))))))
+
+
+(defn pre-process-data-halfway
+  "Pre-processes input by extracting the digits but this time add the first
+  half of the digits list at the end to make the sequence circular"
+  [input]
+  (let [digits (vec (map
+                      #(Character/getNumericValue %)
+                      (seq (str input))))]
+    (into digits (take (/ (count digits) 2) digits))))
+
+(defn get-input-size
+  "Returns the number of digits in the sequence"
+  [input]
+  (count (str input)))
+
+(defn captcha-halfway
+  "Processes the captcha by taking into account the digit halfway around
+  the circular list instead of the next one in line"
+  [input]
+  (let [digits (pre-process-data-halfway input)]
+    (loop [acc 0
+           partitioned-digits (partition (+ 1 (/ (get-input-size input) 2)) 1 digits)]
+      (if (empty? partitioned-digits)
+        acc
+        (if (= (-> partitioned-digits first first)
+               (-> partitioned-digits first last))
+          (recur (+ acc (-> partitioned-digits first first))
+                 (rest partitioned-digits))
+          (recur acc (rest partitioned-digits)))))))

--- a/test/clj_advent_of_code_2017/agericus_test.clj
+++ b/test/clj_advent_of_code_2017/agericus_test.clj
@@ -13,3 +13,21 @@
     (is (= (captcha 1111) 4))
     (is (= (captcha 1234) 0))
     (is (= (captcha 91212129) 9))))
+
+(deftest test-pre-process-data-halfway
+  (testing "Testing pre-process-data-halfway"
+    (is (= (pre-process-data-halfway 1122) [1 1 2 2 1 1]))
+    (is (= (pre-process-data-halfway 4091) [4 0 9 1 4 0]))))
+
+(deftest test-get-input-size
+  (testing "Get input size"
+    (is (= (get-input-size 1212) 4))
+    (is (= (get-input-size 123425) 6))))
+
+(deftest test-catpcha-halfway
+  (testing "Testing captcha-halfway"
+    (is (= (captcha-halfway 1212) 6))
+    (is (= (captcha-halfway 1221) 0))
+    (is (= (captcha-halfway 123425) 4))
+    (is (= (captcha-halfway 123123) 12))
+    (is (= (captcha-halfway 12131415)) 4)))


### PR DESCRIPTION
This PR implements [advent of code day 1, part 2 puzzle](http://adventofcode.com/2017/day/2) but instead of doing the comparison on the next digit, it does it on the digit halfway around the circular list.